### PR TITLE
De novo cnn handle empty quality reads

### DIFF
--- a/denovocnn.def
+++ b/denovocnn.def
@@ -1,0 +1,28 @@
+Bootstrap: docker
+From: continuumio/miniconda3
+
+%files
+    . /app
+
+%post
+    apt-get update
+    apt-get install -y ffmpeg libsm6 libxext6
+
+    cd /app
+
+    conda env create -f environment.yml
+
+    export PATH=/opt/conda/envs/tensorflow_env/bin:$PATH
+
+    pip install -e /app
+
+    chmod +x /app/apply_denovocnn.sh
+    chmod -R 755 /app/models
+
+%environment
+    export PATH=/opt/conda/envs/tensorflow_env/bin:$PATH
+    export CONDA_DEFAULT_ENV=tensorflow_env
+    export PYTHONPATH=/app:$PYTHONPATH
+
+%runscript
+    exec /app/apply_denovocnn.sh "$@"

--- a/denovonet/dataset.py
+++ b/denovonet/dataset.py
@@ -138,7 +138,7 @@ class Dataset:
         total_batches = len(dataset_batches)
 
         total = len(dataset_batches)
-        print(f"starting batch analysis of {total} batches")
+        print(f"starting analysis of {total} batches of potential denovos")
         for i, batch in enumerate(dataset_batches, 1):
             batch_results = pool.map(
                 partial(debug_apply_model, reference_genome_path=reference_genome_path),
@@ -150,9 +150,6 @@ class Dataset:
         pool.close()
         print("Applying DeNovoCNN finished, time elapsed:", datetime.datetime.now() - start)
         sys.stdout.flush()
-
-        # flattern results
-        results = [pred for sub_pred in results for pred in sub_pred]
 
         self.dataset['DeNovoCNN probability'] = [res[0] for res in results]
         self.dataset['Child coverage'] = [res[1][0] for res in results]
@@ -257,11 +254,11 @@ def load_variant(chromosome, start, end, bam, reference_genome):
         if chromosome[:3] != 'chr':
             new_chromosome = 'chr' + chromosome
             print(f"reatempted using {new_chromosome} instead of {chromosome}")
-            return SingleVariant(str(chromosome), int(start), int(end), bam, reference_genome)
+            return SingleVariant(str(new_chromosome), int(start), int(end), bam, reference_genome)
         elif chromosome[:3] == 'chr':
             new_chromosome = chromosome[3:]
             print(f"reatempted using {new_chromosome} instead of {chromosome}")
-            return SingleVariant(str(chromosome), int(start), int(end), bam, reference_genome)
+            return SingleVariant(str(new_chromosome), int(start), int(end), bam, reference_genome)
         else:
             raise
 
@@ -332,10 +329,7 @@ def apply_model(row, models_dict, reference_genome_path):
     trio_variant = get_image(tuple(row) + (None, None), reference_genome_path)
 
     try:
-        # predict
-        img = trio_variant.image.astype(np.float32)
-        img = np.expand_dims(img, axis=0)
-        prediction = models_dict[var_type].predict(img, verbose=0)
+        prediction = trio_variant.predict(models_dict[var_type])
         prediction_dnm = str(round(1. - prediction[0, 0], 3))
         child_coverage = trio_variant.child_variant.start_coverage
         father_coverage = trio_variant.father_variant.start_coverage
@@ -363,6 +357,9 @@ def debug_apply_model(row, reference_genome_path):
         return None
 
 def apply_model_batch(rows, models_cfg, reference_genome_path):
+    """
+    applies  DeNovoCNN models from models_cfg to a batch of rows from a processed dataframe
+    """
     models_dict = load_models(models_cfg)
     results = []
     for row in rows:

--- a/denovonet/dataset.py
+++ b/denovonet/dataset.py
@@ -21,6 +21,8 @@ along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
 '''
 
 import os
+os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
+
 import sys
 import numpy as np
 import pandas as pd
@@ -32,7 +34,6 @@ import cv2
 import pysam
 import tensorflow as tf
 from denovonet.variants import SingleVariant, TrioVariant
-
 
 class Dataset:
     """
@@ -98,7 +99,7 @@ class Dataset:
         sys.stdout.flush()
         start = datetime.datetime.now()
 
-        pool = mp.Pool(n_jobs)
+        pool = mp.Pool(n_jobs, initializer=init_worker, initargs=(models_cfg,))
 
         _ = pool.map(
             partial(save_image, folder=folder, reference_genome_path=reference_genome_path),
@@ -124,18 +125,27 @@ class Dataset:
                                         'Variant type', 'Child BAM', 'Father BAM', 'Mother BAM'
                                         ]].values.tolist()
 
-        dataset_batches = [dataset_batches[x:x + batch_size] for x in range(0, len(dataset_batches), batch_size)]
 
+        dataset_batches = [dataset_batches[x:x + batch_size] for x in range(0, len(dataset_batches), batch_size)]
         print(f"Using {n_jobs} CPUs")
+
         sys.stdout.flush()
         start = datetime.datetime.now()
 
-        pool = mp.Pool(n_jobs)
+        pool = mp.Pool(n_jobs, initializer=init_worker, initargs=(models_cfg,))
 
-        results = pool.map(
-            partial(apply_model_batch, models_cfg=models_cfg, reference_genome_path=reference_genome_path),
-            dataset_batches
-        )
+        results = []
+        total_batches = len(dataset_batches)
+
+        total = len(dataset_batches)
+        print(f"starting batch analysis of {total} batches")
+        for i, batch in enumerate(dataset_batches, 1):
+            batch_results = pool.map(
+                partial(debug_apply_model, reference_genome_path=reference_genome_path),
+                batch
+            )
+            results.extend(batch_results)
+            print(f"[{i}/{total}] ({i/total:.1%})", flush=True)
 
         pool.close()
         print("Applying DeNovoCNN finished, time elapsed:", datetime.datetime.now() - start)
@@ -240,15 +250,17 @@ def load_variant(chromosome, start, end, bam, reference_genome):
     :param reference_genome: reference genome AligmnentFile
     :return: SingleVariant class
     """
-
     try:
         return SingleVariant(str(chromosome), int(start), int(end), bam, reference_genome)
     except (ValueError, KeyError):
+        print(f"crash in generation of SingleVariant, attempting to rename {chromosome}")
         if chromosome[:3] != 'chr':
-            chromosome = 'chr' + chromosome
+            new_chromosome = 'chr' + chromosome
+            print(f"reatempted using {new_chromosome} instead of {chromosome}")
             return SingleVariant(str(chromosome), int(start), int(end), bam, reference_genome)
         elif chromosome[:3] == 'chr':
-            chromosome = chromosome[:3]
+            new_chromosome = chromosome[3:]
+            print(f"reatempted using {new_chromosome} instead of {chromosome}")
             return SingleVariant(str(chromosome), int(start), int(end), bam, reference_genome)
         else:
             raise
@@ -321,9 +333,10 @@ def apply_model(row, models_dict, reference_genome_path):
 
     try:
         # predict
-        prediction = trio_variant.predict(models_dict[var_type])
+        img = trio_variant.image.astype(np.float32)
+        img = np.expand_dims(img, axis=0)
+        prediction = models_dict[var_type].predict(img, verbose=0)
         prediction_dnm = str(round(1. - prediction[0, 0], 3))
-
         child_coverage = trio_variant.child_variant.start_coverage
         father_coverage = trio_variant.father_variant.start_coverage
         mother_coverage = trio_variant.mother_variant.start_coverage
@@ -334,13 +347,32 @@ def apply_model(row, models_dict, reference_genome_path):
 
     return prediction_dnm, (child_coverage, father_coverage, mother_coverage)
 
+global_models = None
+
+def init_worker(models_cfg):
+    global global_models
+    global_models = load_models(models_cfg)
+
+def debug_apply_model(row, reference_genome_path):
+    try:
+        global global_models
+        result = apply_model(row, global_models, reference_genome_path)
+        return result
+    except Exception as e:
+        print("FAILED VARIANT:", row, str(e), flush=True)
+        return None
 
 def apply_model_batch(rows, models_cfg, reference_genome_path):
-    """
-    applies  DeNovoCNN models from models_cfg to a batch of rows from a processed dataframe
-    """
     models_dict = load_models(models_cfg)
-    return [apply_model(row, models_dict, reference_genome_path) for row in rows]
+    results = []
+    for row in rows:
+        try:
+            result = apply_model(row, models_dict, reference_genome_path)
+            results.append(result)
+        except Exception as e:
+            print("FAILED VARIANT:", row, str(e), flush=True)
+            results.append(None)
+    return results
 
 
 def apply_models_on_trio(variants_list, output_path, child_bam, father_bam, mother_bam,
@@ -373,7 +405,6 @@ def apply_models_on_trio(variants_list, output_path, child_bam, father_bam, moth
         dataset[f"{sample} BAM"] = trio_cfg[sample]['bam_path']
 
     print(f"Start apply in parallel, n_jobs={n_jobs}")
-
     # apply models
     dataset = Dataset(dataset=dataset, convert_to_inner_format=convert_to_inner_format)
 

--- a/denovonet/variants.py
+++ b/denovonet/variants.py
@@ -59,7 +59,7 @@ class SingleVariant():
 
         # run encoding the variant as 2 numpy arrays
         self.encode_pileup()
-        
+
     # variant area: variant location +- N positions
     @property
     def region_start(self):
@@ -100,17 +100,22 @@ class SingleVariant():
                 raise Exception("Chromosome for reference should be one of ", self.REFERENCE_GENOME.references)
 
     def encode_pileup(self):
-        """
-            Iterates over all the reads in the area of interest and
-            encodes every read as 2 numpy arrays: 
-            encoded nucleotides and corresponding qualities
-        """
-        for idx, read in enumerate(self.bam_data.fetch(reference=self.chromosome, start=self.start, end=self.end)):
+        for idx, read in enumerate(
+            self.bam_data.fetch(reference=self.chromosome, start=self.start, end=self.end)
+        ):
             if idx >= IMAGE_HEIGHT:
                 break
-            self.pileup_encoded[idx, :], self.quality_encoded[idx, :] = (
-                self._get_read_encoding(read, False)
-            )
+            try:
+                enc, qual = self._get_read_encoding(read, False)
+                self.pileup_encoded[idx, :] = enc
+                self.quality_encoded[idx, :] = qual
+            except Exception as e:
+                print(
+                    f"Error processing read for pileup, in variant "
+                    f"{self.chromosome}:{self.start}-{self.end} "
+                    f"in bamfile {self.bam_path}, skipping it: {e}"
+                )
+                continue
             
     def _get_read_encoding(self, read, debug=False):
         """

--- a/denovonet/variants.py
+++ b/denovonet/variants.py
@@ -100,6 +100,11 @@ class SingleVariant():
                 raise Exception("Chromosome for reference should be one of ", self.REFERENCE_GENOME.references)
 
     def encode_pileup(self):
+        """
+            Iterates over all the reads in the area of interest and
+            encodes every read as 2 numpy arrays:
+            encoded nucleotides and corresponding qualities
+        """
         for idx, read in enumerate(
             self.bam_data.fetch(reference=self.chromosome, start=self.start, end=self.end)
         ):
@@ -113,7 +118,7 @@ class SingleVariant():
                 print(
                     f"Error processing read for pileup, in variant "
                     f"{self.chromosome}:{self.start}-{self.end} "
-                    f"in bamfile {self.bam_path}, skipping it: {e}"
+                    f"in bamfile {self.bam_path}, skipping this read: {e}"
                 )
                 continue
             


### PR DESCRIPTION
DeNovoCNN crashed on specific variants in the test samples after transfering to Dragen 4.4.7 SNV calling. 
It would consitently crash with a: "chromosome name not part of the reference" error. To fix this i performed the following:

- Failure in load_variant caused the chromname to be automaticcaly swapped between chr1 & 1. This caused the "chrom not part in reference error" because it would swap them incorrectly. I've added logging when this happens to make it clearer going forward.
- SingleVariant crashed due to encode_pileup in specific samples and regions. This seemed to happen when a read failed to obtain both an encoding pileup and a quality pileup, resulting in no quality scores. This would result in it crashing. I've added a try except, skipping this read from the pileup when this occurs, and logging a warning message, but continuing with other reads.
- I've added logging when apply_model crashes on a variant, to log on which variant it crashes
- Added logging on the number of batches denovCNN uses, and how far along the analysis is based on the number of processed batches.
- Removed some tensorflow warnings by setting: os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
- Loaded the global_models once, instead of once per tensor core.
- Added a defenition file to make generating a apptainer/docker/singularity container more straightforward (tested it with apptainer).

Greetings Jos


